### PR TITLE
Benchmarks fix

### DIFF
--- a/deep_folding/anatomist_tools/benchmark_generation.py
+++ b/deep_folding/anatomist_tools/benchmark_generation.py
@@ -241,7 +241,7 @@ def get_sub_list(subjects_list):
 
 
 def generate(b_num, side, ss_size, sulci_list, mode='suppress', bench_size=150,
-             subjects_list=None):
+             subjects_list=None, bbox_dir=_DEFAULT_BBOX_DIR):
     """
     Generates a benchmark
 
@@ -252,7 +252,7 @@ def generate(b_num, side, ss_size, sulci_list, mode='suppress', bench_size=150,
         mode: string giving the type of benchmark to create ('suppress', 'add'
               or 'mix')
     """
-    benchmark = Benchmark(b_num, side, ss_size, sulci_list)
+    benchmark = Benchmark(b_num, side, ss_size, sulci_list, bbox_dir=bbox_dir)
     abnormality_test = []
     givers = []
     subjects_list = get_sub_list(subjects_list)

--- a/deep_folding/anatomist_tools/benchmark_generation.py
+++ b/deep_folding/anatomist_tools/benchmark_generation.py
@@ -142,6 +142,7 @@ class Benchmark():
         bck_map = self.surfaces[surface]['aims_ss']
         for voxel in bck_map[0].keys():
             self.skel.setValue(0, voxel[0], voxel[1], voxel[2])
+            print('la')
 
         bck_map_bottom = self.surfaces[surface]['aims_bottom']
         for voxel in bck_map_bottom[0].keys():

--- a/deep_folding/anatomist_tools/benchmark_generation.py
+++ b/deep_folding/anatomist_tools/benchmark_generation.py
@@ -142,7 +142,6 @@ class Benchmark():
         bck_map = self.surfaces[surface]['aims_ss']
         for voxel in bck_map[0].keys():
             self.skel.setValue(0, voxel[0], voxel[1], voxel[2])
-            print('la')
 
         bck_map_bottom = self.surfaces[surface]['aims_bottom']
         for voxel in bck_map_bottom[0].keys():

--- a/deep_folding/anatomist_tools/benchmark_pipeline.py
+++ b/deep_folding/anatomist_tools/benchmark_pipeline.py
@@ -147,7 +147,8 @@ def main(argv):
 
     print('=================== Selection and possible alteration of benchmark skeletons ===================')
     generate(b_num, side, ss_size, sulci_list=sulcus,
-             mode=mode, bench_size=bench_size, subjects_list=subjects_list)
+             mode=mode, bench_size=bench_size, subjects_list=subjects_list,
+             bbox_dir=bbox_dir)
 
     bbox = compute_max_box(sulcus, side, src_dir=bbox_dir)
     print(bbox)
@@ -180,10 +181,11 @@ def main(argv):
             # Crop of the images
             file = os.path.join(tgt_dir, img[:-7] + '_normalized.nii.gz')
             if mode == 'random':
-                # 40 instead of 0 in order to avoid crops with only black voxels
-                random_x = random.randint(40, 157-box_size[0]-1)
-                random_y = random.randint(0, 189-box_size[1]-1)
-                random_z = random.randint(0, 136-box_size[2]-1)
+                # 42 instead of 0 in order to avoid crops with only black voxels
+                # Int 108 and 91 depend on downsampling and normalization
+                random_x = random.randint(0, 42)
+                random_y = random.randint(0, 108-box_size[1]-1)
+                random_z = random.randint(0, 91-box_size[2]-1)
                 print(random_x, random_y, random_z)
                 xmax, ymax, zmax = random_x + box_size[0], random_y + box_size[1], random_z + box_size[2]
                 cmd_bounding_box = ' -x ' + str(random_x) + ' -y ' + str(random_y) + \


### PR DESCRIPTION
Benchmark_generation fix:
- addition of  possibility to specify bounding box to use
- bounding_box specifications for random benchmark

dataset_gen_pipe update to work with any data repository:
- addition of possibility to specify morphologist_dir
- new way of listing sub-directories in morphologist dir in order to keep _only_ folder (and not files)