### PR TITLE
use an info.py file to allow integration with casa-distro/bv_maker

### DIFF
--- a/deep_folding/info.py
+++ b/deep_folding/info.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+version_major = 0
+version_minor = 0
+version_micro = 1
+version_extra = ''
+
+# Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
+__version__ = "%s.%s.%s%s" % (version_major,
+                              version_minor,
+                              version_micro,
+                              version_extra)
+CLASSIFIERS = ['Development Status :: 5 - Production/Stable',
+               'Environment :: Console',
+               'Intended Audience :: Developers',
+               'Intended Audience :: Science/Research',
+               'Intended Audience :: Education',
+               'Operating System :: OS Independent',
+               'Programming Language :: Python',
+               'Topic :: Scientific/Engineering',
+               'Topic :: Utilities',
+               'Topic :: Software Development :: Libraries']
+
+
+description = 'Deep learning utilities to characterize sulcus patterns'
+
+# versions for dependencies
+SPHINX_MIN_VERSION = '1.0'
+
+# Main setup parameters
+NAME = 'deep_folding'
+PROJECT = 'deep_folding'
+ORGANISATION = "neurospin"
+MAINTAINER = "nobody"
+MAINTAINER_EMAIL = "support@neurospin.info"
+DESCRIPTION = description
+URL = "https://github.com/neurospin/deep_folding"
+DOWNLOAD_URL = "https://github.com/neurospin/deep_folding"
+LICENSE = "CeCILL license version 2"
+AUTHOR = "Louise Guillon and Joel Chavas"
+AUTHOR_EMAIL = ""
+PLATFORMS = "OS Independent"
+PROVIDES = ["deep_folding"]
+REQUIRES = ['six', 'numpy', 'pytest', 'GitPython', 'typing', 'joblib', 'pqdm']
+EXTRA_REQUIRES = {
+    "plotting": ["matplotlib"],
+    "doc": ["sphinx>=" + SPHINX_MIN_VERSION]}
+
+brainvisa_build_model = 'pure_python'
+

--- a/deep_folding/info.py
+++ b/deep_folding/info.py
@@ -41,7 +41,8 @@ AUTHOR = "Louise Guillon and Joel Chavas"
 AUTHOR_EMAIL = ""
 PLATFORMS = "OS Independent"
 PROVIDES = ["deep_folding"]
-REQUIRES = ['six', 'numpy', 'pytest', 'GitPython', 'typing', 'joblib', 'pqdm']
+REQUIRES = ['six', 'numpy', 'pytest', 'GitPython', 'typing', 'joblib',
+            'tqdm>=4.36', 'pqdm']  # , 'moving_averages']
 EXTRA_REQUIRES = {
     "plotting": ["matplotlib"],
     "doc": ["sphinx>=" + SPHINX_MIN_VERSION]}

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,20 @@
 from setuptools import setup, find_packages
 
+release_info = {}
+python_dir = os.path.dirname(__file__)
+with open(os.path.join(python_dir, "deep_folding", "info.py")) as f:
+    code = f.read()
+    exec(code, release_info)
+
 setup(
-    name='deep_folding',
-    version='0.0.1',
+    name=release_info['NAME'],
+    version=release_info['__version__'],
     packages=find_packages(exclude=['tests*', 'notebooks*']),
-    license='CeCILL license version 2',
-    description='Deep learning utilities to characterize sulcus patterns',
+    license=release_info['LICENSE'],
+    description=release_info['DESCRIPTION'],
     long_description=open('README.rst').read(),
-    install_requires=['six', 'numpy', 'pytest', 'GitPython', 'typing', 'joblib', 'pqdm'],
-    url='https://github.com/neurospin/deep_folding',
-    author='Louise Guillon and Joel Chavas',
-    author_email=''
+    install_requires=release_info["REQUIRES"],
+    url=release_info['DOWNLOAD_URL'],
+    author=release_info['AUTHOR'],
+    author_email=release_info['AUTHOR_EMAIL']
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description=release_info['DESCRIPTION'],
     long_description=open('README.rst').read(),
     install_requires=release_info["REQUIRES"],
-    url=release_info['DOWNLOAD_URL'],
+    url=release_info['URL'],
     author=release_info['AUTHOR'],
     author_email=release_info['AUTHOR_EMAIL']
 )


### PR DESCRIPTION
this is just a separation of what was in setup.py into 2 files, the
info.py file being read by bv_maker not only for setup. Moreover it
allows to get info at runtime (to get library version etc) when needed.