### PR TITLE
Filename Parameters

### DIFF
--- a/deep_folding/brainvisa/resample_files.py
+++ b/deep_folding/brainvisa/resample_files.py
@@ -435,7 +435,7 @@ class FoldLabelResampler(FileResampler):
         # 'side'
         self.resampled_file = join(
             self.resampled_dir,
-            f'%(side)s' + output_filename + + '%(subject)s.nii.gz')
+            f'%(side)s' + output_filename + '%(subject)s.nii.gz')
 
         # subjects are detected as the nifti file names under src_dir
         self.expr = '^.' + src_filename + '(.*).nii.gz$'

--- a/deep_folding/brainvisa/resample_files.py
+++ b/deep_folding/brainvisa/resample_files.py
@@ -361,6 +361,8 @@ class SkeletonResampler(FileResampler):
             side: either 'L' or 'R', hemisphere side
             out_voxel_size: float giving voxel size in mm
             parallel: does parallel computation if True
+            src_filename : name of skeleton files (format : "<SIDE><src_filename><SUBJECT>.nii.gz")
+            output_filename : name of generated files (format : "<SIDE><output_filename><SUBJECT>.nii.gz")
         """
         super(SkeletonResampler, self).__init__(
             src_dir=src_dir, resampled_dir=resampled_dir,
@@ -415,6 +417,8 @@ class FoldLabelResampler(FileResampler):
             side: either 'L' or 'R', hemisphere side
             out_voxel_size: float giving voxel size in mm
             parallel: does parallel computation if True
+            src_filename : name of fold label files (format : "<SIDE><src_filename><SUBJECT>.nii.gz")
+            output_filename : name of generated files (format : "<SIDE><output_filename><SUBJECT>.nii.gz")
         """
         super(FoldLabelResampler, self).__init__(
             src_dir=src_dir, resampled_dir=resampled_dir,


### PR DESCRIPTION
Add source and output filename parameters to resample_file function. This allows the user to resample skeletons or foldlabels with a specific name corresponding to the format \<SIDE\>\<src_filename\>\<SUBJECT\>.nii.gz and to rename the output filenames according to the format \<SIDE\>\<output_filename\>\<SUBJECT\>.nii.gz.